### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.5.0
+    - uses: actions/checkout@v3.1.0
     - name: Set up JDK 8
       uses: actions/setup-java@v3.6.0
       with:
@@ -17,7 +17,7 @@ jobs:
     - name: Download BuildTools
       run: wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.6.0
       with:
         distribution: temurin
         java-version: 17
@@ -27,7 +27,7 @@ jobs:
       run: java -jar BuildTools.jar --rev 1.19.2 --remapped
     - name: Build with Gradle
       run: ./gradlew obfuscate
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3.1.1
       with:
         name: UltraCosmetics-dev
         path: build/libs/UltraCosmetics-*.jar

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.6.0
       with:
         distribution: temurin
         java-version: 8

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v3.1.0 #https://github.com/actions/checkout/releases
     - name: Set up JDK 8
-      uses: actions/setup-java@v3.6.0
+      uses: actions/setup-java@v3.6.0 #https://github.com/actions/setup-java/releases
       with:
         distribution: temurin
         java-version: 8
     - name: Download BuildTools
       run: wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
     - name: Set up JDK 17
-      uses: actions/setup-java@v3.6.0
+      uses: actions/setup-java@v3.6.0 #https://github.com/actions/setup-java/releases
       with:
         distribution: temurin
         java-version: 17
@@ -27,7 +27,7 @@ jobs:
       run: java -jar BuildTools.jar --rev 1.19.2 --remapped
     - name: Build with Gradle
       run: ./gradlew obfuscate
-    - uses: actions/upload-artifact@v3.1.1
+    - uses: actions/upload-artifact@v3.1.1 #https://github.com/actions/upload-artifact/releases
       with:
         name: UltraCosmetics-dev
         path: build/libs/UltraCosmetics-*.jar


### PR DESCRIPTION
### What is the purpose of this pull request?
Update Actions to get rid of deprecation warnings
Also added links to their release pages as a comment to easily find their latest version in the future (Might also do this soon for all of UC's dependencies)

![image](https://user-images.githubusercontent.com/65610536/197672100-1de8f92d-ea0d-40ae-abe9-95e07d5d029a.png)




[This build](https://github.com/Chris6ix/UltraCosmetics/actions/runs/3317787977) vs [Build before update](https://github.com/Chris6ix/UltraCosmetics/actions/runs/3317566519)

#### Changes

- [x] Updated `actions/checkout` from `v2` to `v3.1.0` (Latest version as of now)
- [x] Updated `actions/setup-java` from `v2` to `v3.6.0` (Latest version as of now)
- [x] Updated `actions/upload-artifact` from `v2` to `v3.1.1` (Latest version as of now)
- [x] Added release page links as comments