### PR TITLE
Nerf DruggedHorse mount confusion potion effect

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/mounts/MountDruggedHorse.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/mounts/MountDruggedHorse.java
@@ -30,7 +30,7 @@ public class MountDruggedHorse extends MountAbstractHorse {
         ((Horse)getEntity()).setJumpStrength(1.3);
 
         Bukkit.getScheduler().runTaskLater(getUltraCosmetics(), () -> {
-            getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 10000000, 1));
+            getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 100, 0));
             effectPlayer = getPlayer();
         }, 1);
     }


### PR DESCRIPTION
### What is the purpose of this pull request?

Nerf the DruggedHorse mount confusion potion effect.
Makes the DruggedHorse mount much more enjoyable and playable. The permanent nausea effect can cause real nausea and migraine (https://feedback.minecraft.net/hc/en-us/community/posts/360043589872-An-option-to-toggle-nausea-is-necessary). If you want to use this mount for a longer period of time you have to set the "Distortion Effects" option in Minecraft to "OFF".

#### Changes

- [x] Nerfed DruggedHorse mount confusion potion effect
