### PR TITLE
Fix messages files pr guideline in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 ## Pull Request Guidelines
 
 - When submitting a pull request, please make sure you're using the [pull request template](PULL_REQUEST_TEMPLATE.md).
-- Do not submit pull requests that modify existing strings in the messages files.
-  Changes to those strings should be done through [Crowdin](https://crowdin.com/project/ultracosmetics), because editing them manually can cause Crowdin to lose translations.
-  Adding new strings to the messages files is allowed.
+- Do not submit pull requests that fix typos in the messages files.
+  Typos in translations or source strings should be fixed/reported on our [Crowdin page](https://crowdin.com/project/ultracosmetics).
+- Do not submit pull requests that add translations.
+  Please submit translations through [Crowdin](https://crowdin.com/project/ultracosmetics).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,3 +25,4 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
   Typos in source strings or translations should be reported/fixed on our [Crowdin page](https://crowdin.com/project/ultracosmetics).
 - Do not submit pull requests that add translations.
   Please submit translations through [Crowdin](https://crowdin.com/project/ultracosmetics).
+- Adding, modifying or deleting strings in the messages_en.yml file is allowed.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,6 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 - When submitting a pull request, please make sure you're using the [pull request template](PULL_REQUEST_TEMPLATE.md).
 - Do not submit pull requests that fix typos in the messages files.
-  Typos in translations or source strings should be fixed/reported on our [Crowdin page](https://crowdin.com/project/ultracosmetics).
+  Typos in source strings or translations should be reported/fixed on our [Crowdin page](https://crowdin.com/project/ultracosmetics).
 - Do not submit pull requests that add translations.
   Please submit translations through [Crowdin](https://crowdin.com/project/ultracosmetics).


### PR DESCRIPTION
### What is the purpose of this pull request?

I fixed the pull request guideline in the CONTRIBUTING.md regarding Crowdin and the messages files. 
It's the right and intended behavior that Crowdin loses translations when you modify a source string, otherwise we would have wrong/old translations in the translation files. 
Typos in source strings should be fixed on Crowdin, because they don't have to be translated again.
