### PR TITLE
Convert the Rainbow projectile effect to use timed-based rainbow colors

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffect.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffect.java
@@ -5,6 +5,7 @@ import be.isach.ultracosmetics.cosmetics.Cosmetic;
 import be.isach.ultracosmetics.cosmetics.Updatable;
 import be.isach.ultracosmetics.cosmetics.type.ParticleEffectType;
 import be.isach.ultracosmetics.player.UltraPlayer;
+import be.isach.ultracosmetics.util.ColorUtils;
 import be.isach.ultracosmetics.util.ItemFactory;
 import be.isach.ultracosmetics.util.MathUtils;
 import be.isach.ultracosmetics.util.Particles;
@@ -60,7 +61,7 @@ public abstract class ParticleEffect extends Cosmetic<ParticleEffectType> implem
                                 if (getType().getConfigName().equals("AngelWings")) {
                                     color = new Particles.OrdinaryColor(255, 255, 255);
                                 } else if (getType().getConfigName().equals("RainbowWings")) {
-                                    color = ParticleEffectRainbowWings.getColor();
+                                    color = new Particles.OrdinaryColor(ColorUtils.getRainbowColor());
                                 }
                                 for (int i = 0; i < getModifiedAmount(15); i++) {
                                     getType().getEffect().display(color, getPlayer().getLocation().add(MathUtils.randomDouble(-0.8, 0.8), 1 + MathUtils.randomDouble(-0.8, 0.8), MathUtils.randomDouble(-0.8, 0.8)), 128);

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectRainbowWings.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectRainbowWings.java
@@ -3,6 +3,7 @@ package be.isach.ultracosmetics.cosmetics.particleeffects;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.cosmetics.type.ParticleEffectType;
 import be.isach.ultracosmetics.player.UltraPlayer;
+import be.isach.ultracosmetics.util.ColorUtils;
 import be.isach.ultracosmetics.util.Particles;
 
 import org.bukkit.Location;
@@ -35,12 +36,12 @@ public class ParticleEffectRainbowWings extends ParticleEffect {
     }
 
     private void drawParticles(Location location) {
+        Particles.OrdinaryColor nextColor = new Particles.OrdinaryColor(ColorUtils.getRainbowColor());
         double space = 0.2;
         double defX = location.getX() - (space * shape[0].length / 2) + space;
         double x = defX;
         double y = location.clone().getY() + 2;
         double angle = -((location.getYaw() + 180) / 60);
-        Particles.OrdinaryColor nextColor = getColor();
         angle += (location.getYaw() < -180 ? 3.25 : 2.985);
 
         for (boolean[] aShape : shape) {
@@ -89,53 +90,6 @@ public class ParticleEffectRainbowWings extends ParticleEffect {
         final float newZ = (float) (loc.getZ() + (1 * Math.sin(Math.toRadians(loc.getYaw() + 90))));
         final float newX = (float) (loc.getX() + (1 * Math.cos(Math.toRadians(loc.getYaw() + 90))));
         return new Vector(newX - loc.getX(), 0, newZ - loc.getZ());
-    }
-
-    /**
-     * Generates a color in the rainbow sequence based on the current time.
-     *
-     * @return a Particles.OrdinaryColor representing the color for the current time.
-     */
-    public static Particles.OrdinaryColor getColor() {
-        long currentEpochMilliseconds = System.currentTimeMillis();
-        long currentEpochSeconds = currentEpochMilliseconds / 1000L;
-
-        double secondsPerPhase = 2;
-        double phase = currentEpochSeconds % (6 * secondsPerPhase);
-        phase = phase / secondsPerPhase;
-
-        double millisecondsToAdjustBy = currentEpochMilliseconds % (secondsPerPhase * 1000);
-
-        // There's a change of a specific number of rgb values in a single tick. This calculation is basically the
-        // current tick (or milliseconds) multiplied by 255 to get the rgb value.
-        int currentRotatingRgbValue = (int) (millisecondsToAdjustBy * 0.255 / secondsPerPhase);
-
-        int red = 0;
-        int green = 0;
-        int blue = 0;
-
-        // There are six phases in a rainbow when adjusting rgb values. This if-else encapsulates those six phases.
-        if (phase >= 0 && phase < 1) { // Red is at 255, Green goes to 255
-            red = 255;
-            green = currentRotatingRgbValue;
-        } else if (phase >= 1 && phase < 2) { // Red goes to 0
-            red = 255 - currentRotatingRgbValue;
-            green = 255;
-        } else if (phase >= 2 && phase < 3) { // Blue goes to 255
-            green = 255;
-            blue = currentRotatingRgbValue;
-        } else if (phase >= 3 && phase < 4) { // Green goes to 0
-            green = 255 - currentRotatingRgbValue;
-            blue = 255;
-        } else if (phase >= 4 && phase < 5) { // Red goes to 255
-            red = currentRotatingRgbValue;
-            blue = 255;
-        } else if (phase >= 5 && phase < 6) { // Blue goes to 0
-            red = 255;
-            blue = 255 - currentRotatingRgbValue;
-        }
-
-        return new Particles.OrdinaryColor(red, green, blue);
     }
 }
 

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/projectileeffects/ProjectileEffectRainbow.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/projectileeffects/ProjectileEffectRainbow.java
@@ -3,53 +3,21 @@ package be.isach.ultracosmetics.cosmetics.projectileeffects;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.cosmetics.type.ProjectileEffectType;
 import be.isach.ultracosmetics.player.UltraPlayer;
+import be.isach.ultracosmetics.util.ColorUtils;
 import be.isach.ultracosmetics.util.Particles;
 
 import org.bukkit.entity.Projectile;
 
-public class ProjectileEffectRainbow extends ProjectileEffect {
-    private int i = 0;
+import java.awt.Color;
 
+public class ProjectileEffectRainbow extends ProjectileEffect {
     public ProjectileEffectRainbow(UltraPlayer owner, ProjectileEffectType type, UltraCosmetics ultraCosmetics) {
         super(owner, type, ultraCosmetics);
     }
 
     @Override
     public void showParticles(Projectile projectile) {
-        i++;
-
-        switch (i) {
-            case 1:
-                Particles.REDSTONE.display(255, 0, 0, projectile.getLocation());
-                break;
-            case 2:
-                Particles.REDSTONE.display(255, 135, 0, projectile.getLocation());
-                break;
-            case 3:
-                Particles.REDSTONE.display(255, 211, 0, projectile.getLocation());
-                break;
-            case 4:
-                Particles.REDSTONE.display(222, 255, 10, projectile.getLocation());
-                break;
-            case 5:
-                Particles.REDSTONE.display(161, 255, 10, projectile.getLocation());
-                break;
-            case 6:
-                Particles.REDSTONE.display(10, 255, 153, projectile.getLocation());
-                break;
-            case 7:
-                Particles.REDSTONE.display(10, 239, 255, projectile.getLocation());
-                break;
-            case 8:
-                Particles.REDSTONE.display(20, 125, 245, projectile.getLocation());
-                break;
-            case 9:
-                Particles.REDSTONE.display(88, 10, 255, projectile.getLocation());
-                break;
-            case 10:
-                Particles.REDSTONE.display(190, 10, 255, projectile.getLocation());
-                i = 0;
-                break;
-        }
+        Color color = ColorUtils.getRainbowColor(0.5);
+        Particles.REDSTONE.display(color.getRed(), color.getGreen(), color.getBlue(), projectile.getLocation());
     }
 }

--- a/core/src/main/java/be/isach/ultracosmetics/util/ColorUtils.java
+++ b/core/src/main/java/be/isach/ultracosmetics/util/ColorUtils.java
@@ -26,9 +26,7 @@ public class ColorUtils {
         long currentEpochMilliseconds = System.currentTimeMillis();
         long currentEpochSeconds = currentEpochMilliseconds / 1000L;
 
-        double phase = currentEpochSeconds % (6 * secondsPerPhase);
-        phase = phase / secondsPerPhase;
-
+        int phase = (int) ((currentEpochSeconds % (6 * secondsPerPhase)) / secondsPerPhase);
         double millisecondsToAdjustBy = currentEpochMilliseconds % (secondsPerPhase * 1000);
 
         // There's a change of a specific number of rgb values in a single tick. This calculation is basically the
@@ -40,22 +38,22 @@ public class ColorUtils {
         int blue = 0;
 
         // There are six phases in a rainbow when adjusting rgb values. This if-else encapsulates those six phases.
-        if (phase >= 0 && phase < 1) { // Red is at 255, Green goes to 255
+        if (phase == 0) { // Red is at 255, Green goes to 255
             red = 255;
             green = currentRotatingRgbValue;
-        } else if (phase >= 1 && phase < 2) { // Red goes to 0
+        } else if (phase == 1) { // Red goes to 0
             red = 255 - currentRotatingRgbValue;
             green = 255;
-        } else if (phase >= 2 && phase < 3) { // Blue goes to 255
+        } else if (phase == 2) { // Blue goes to 255
             green = 255;
             blue = currentRotatingRgbValue;
-        } else if (phase >= 3 && phase < 4) { // Green goes to 0
+        } else if (phase == 3) { // Green goes to 0
             green = 255 - currentRotatingRgbValue;
             blue = 255;
-        } else if (phase >= 4 && phase < 5) { // Red goes to 255
+        } else if (phase == 4) { // Red goes to 255
             red = currentRotatingRgbValue;
             blue = 255;
-        } else if (phase >= 5 && phase < 6) { // Blue goes to 0
+        } else if (phase == 5) { // Blue goes to 0
             red = 255;
             blue = 255 - currentRotatingRgbValue;
         }

--- a/core/src/main/java/be/isach/ultracosmetics/util/ColorUtils.java
+++ b/core/src/main/java/be/isach/ultracosmetics/util/ColorUtils.java
@@ -1,0 +1,65 @@
+package be.isach.ultracosmetics.util;
+
+import java.awt.Color;
+
+public class ColorUtils {
+    /**
+     * Generates a color in the rainbow sequence based on the current time. Use this method to get the smoothest
+     * transition between all colors of the rainbow.
+     *
+     * @return a Color representing the color for the current time.
+     */
+    public static Color getRainbowColor() {
+        return getRainbowColor(2);
+    }
+
+    /**
+     * Generates a color in the rainbow sequence based on the current time.
+     *
+     * @param secondsPerPhase number of seconds that each rainbow phase will last. There are a total of 6 phases. So,
+     *                        this number multiplied by 6 will be the total amount of time until the colors start
+     *                        repeating themselves.
+     *
+     * @return a Color representing the color for the current time.
+     */
+    public static Color getRainbowColor(double secondsPerPhase) {
+        long currentEpochMilliseconds = System.currentTimeMillis();
+        long currentEpochSeconds = currentEpochMilliseconds / 1000L;
+
+        double phase = currentEpochSeconds % (6 * secondsPerPhase);
+        phase = phase / secondsPerPhase;
+
+        double millisecondsToAdjustBy = currentEpochMilliseconds % (secondsPerPhase * 1000);
+
+        // There's a change of a specific number of rgb values in a single tick. This calculation is basically the
+        // current tick (or milliseconds) multiplied by 255 to get the rgb value.
+        int currentRotatingRgbValue = (int) (millisecondsToAdjustBy * 0.255 / secondsPerPhase);
+
+        int red = 0;
+        int green = 0;
+        int blue = 0;
+
+        // There are six phases in a rainbow when adjusting rgb values. This if-else encapsulates those six phases.
+        if (phase >= 0 && phase < 1) { // Red is at 255, Green goes to 255
+            red = 255;
+            green = currentRotatingRgbValue;
+        } else if (phase >= 1 && phase < 2) { // Red goes to 0
+            red = 255 - currentRotatingRgbValue;
+            green = 255;
+        } else if (phase >= 2 && phase < 3) { // Blue goes to 255
+            green = 255;
+            blue = currentRotatingRgbValue;
+        } else if (phase >= 3 && phase < 4) { // Green goes to 0
+            green = 255 - currentRotatingRgbValue;
+            blue = 255;
+        } else if (phase >= 4 && phase < 5) { // Red goes to 255
+            red = currentRotatingRgbValue;
+            blue = 255;
+        } else if (phase >= 5 && phase < 6) { // Blue goes to 0
+            red = 255;
+            blue = 255 - currentRotatingRgbValue;
+        }
+
+        return new Color(red, green, blue);
+    }
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

1. Converts the Rainbow projectile to use the time-based color generation that was added in #77.

#### Changes

- [x] Moves the time-based rainbow color calculation into a utility class.
- [x] Updates Rainbow Wings to use the utility class.
- [x] Updates the Rainbow projectile to use the utility class.

### Demonstration

#### New projectile colors

![RainbowProjectiles](https://user-images.githubusercontent.com/3119506/209597279-1b76bbda-7352-41f2-ba68-c92698aa6cf1.gif)
