### PR TITLE
Fix Rainbow cosmetics name formatting

### DIFF
--- a/core/src/main/resources/messages/messages_en.yml
+++ b/core/src/main/resources/messages/messages_en.yml
@@ -461,7 +461,7 @@ Particle-Effects:
     name: '&f&lAngel Wings'
     Description: '&7&oBecome an angel!'
   RainbowWings:
-    name: '&l&cR&6a&ei&an&9b&1o&dw&f Wings'
+    name: '&c&lR&6&la&e&li&a&ln&9&lb&1&lo&d&lw &f&lWings'
     Description: '&7&oWings, but full of color!'
   SuperHero:
     name: '&4&lSuper Hero'

--- a/core/src/main/resources/messages/messages_en.yml
+++ b/core/src/main/resources/messages/messages_en.yml
@@ -461,7 +461,7 @@ Particle-Effects:
     name: '&f&lAngel Wings'
     Description: '&7&oBecome an angel!'
   RainbowWings:
-    name: '&c&lR&6&la&e&li&a&ln&9&lb&1&lo&d&lw &f&lWings'
+    name: '&4&lR&6&la&e&li&a&ln&b&lb&9&lo&5&lw &f&lWings'
     Description: '&7&oWings, but full of color!'
   SuperHero:
     name: '&4&lSuper Hero'
@@ -1627,7 +1627,7 @@ Projectile-Effects:
   Equip: '%prefix% &9You equipped %projectile-effectname%'
   Unequip: '%prefix% &9You unequipped %projectile-effectname%'
   Rainbow:
-    name: '&4&lR&6&la&e&li&a&ln&b&lb&1&lo&5&lw'
+    name: '&4&lR&6&la&e&li&a&ln&b&lb&9&lo&5&lw'
     Description: '&7&oRainbow-colored particles'
   Christmas:
     name: '&4&lChrist&f&lmas'


### PR DESCRIPTION
### What is the purpose of this pull request?

1. Fix the formatting of the RainbowWings name. "Rainbow Wings" isn't bold.
2. RainbowWings and Rainbow projectile effect should have the same colors.

![Screenshot (26)](https://user-images.githubusercontent.com/33426785/209889554-4ca8fcec-2719-4b09-92d5-0261ca82884f.png)
