### PR TITLE
Create a lightning strike death effect

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/deatheffects/DeathEffectLightning.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/deatheffects/DeathEffectLightning.java
@@ -1,0 +1,18 @@
+package be.isach.ultracosmetics.cosmetics.deatheffects;
+
+import be.isach.ultracosmetics.UltraCosmetics;
+import be.isach.ultracosmetics.cosmetics.type.DeathEffectType;
+import be.isach.ultracosmetics.player.UltraPlayer;
+import org.bukkit.entity.Player;
+
+public class DeathEffectLightning extends DeathEffect {
+
+    public DeathEffectLightning(UltraPlayer owner, DeathEffectType type, UltraCosmetics ultraCosmetics) {
+        super(owner, type, ultraCosmetics);
+    }
+
+    @Override
+    public void displayParticles(Player player) {
+        player.getWorld().strikeLightningEffect(player.getLocation());
+    }
+}

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/DeathEffectType.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/DeathEffectType.java
@@ -2,9 +2,7 @@ package be.isach.ultracosmetics.cosmetics.type;
 
 import be.isach.ultracosmetics.config.MessageManager;
 import be.isach.ultracosmetics.cosmetics.Category;
-import be.isach.ultracosmetics.cosmetics.deatheffects.DeathEffect;
-import be.isach.ultracosmetics.cosmetics.deatheffects.DeathEffectExplosion;
-import be.isach.ultracosmetics.cosmetics.deatheffects.DeathEffectFirework;
+import be.isach.ultracosmetics.cosmetics.deatheffects.*;
 import be.isach.ultracosmetics.util.Particles;
 
 import com.cryptomorin.xseries.XMaterial;
@@ -21,5 +19,6 @@ public class DeathEffectType extends CosmeticParticleType<DeathEffect> {
     public static void register() {
         new DeathEffectType("Explosion", Particles.EXPLOSION_HUGE, XMaterial.TNT, DeathEffectExplosion.class, false);
         new DeathEffectType("Firework", Particles.FIREWORKS_SPARK, XMaterial.FIREWORK_ROCKET, DeathEffectFirework.class, false);
+        new DeathEffectType("Lightning", Particles.CRIT, XMaterial.DAYLIGHT_DETECTOR, DeathEffectLightning.class, false);
     }
 }

--- a/core/src/main/resources/messages/messages_en.yml
+++ b/core/src/main/resources/messages/messages_en.yml
@@ -1771,6 +1771,9 @@ Death-Effects:
     Description: |-
       &7&oCongratulations!
       &7&oYou... died?
+  Lightning:
+    name: '&f&lLightning'
+    Description: '&7&o⚡ ZAP!'
 Enabled-SelfMorphView: '%prefix% &9You enabled self view for morphs!'
 Disabled-SelfMorphView: '%prefix% &9You disabled self view for morphs!'
 Enabled-Gadgets: '%prefix% &9You enabled gadgets!'


### PR DESCRIPTION
### What is the purpose of this pull request?

1. _What does it do, and what issues does it solve?_

Adds a lightning strike cosmetic to on-death effects! 

#### Changes

- [x] Checked that the death effect actually triggers.
- [x] Verified that it doesn't cause damage.

#### Questions

1. In Spigot, there's a parameter on `strikeLightningEffect(...)` that makes it possible to disallow sound. Should there be a way to do that? Or even to just default to no sound?
2. Is the ASCII lightning symbol okay to use in the description? 😄 

![image](https://user-images.githubusercontent.com/3119506/211736331-fc8d75d2-2891-4e80-8d09-5575d719f0da.png)

![LightningDeathEffect](https://user-images.githubusercontent.com/3119506/211735064-c16789a0-d0c6-4251-ae00-67e7c5cae543.gif)
