### PR TITLE
Use EventPriority Normal.

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
+++ b/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
@@ -49,7 +49,7 @@ public class PlayerListener implements Listener {
         this.menuItem = ItemFactory.getMenuItem();
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler
     public void onJoin(final PlayerJoinEvent event) {
         // Load UltraPlayer whether we use it or not so it's ready
         UltraPlayer up = pm.getUltraPlayer(event.getPlayer());

--- a/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
+++ b/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
@@ -49,7 +49,7 @@ public class PlayerListener implements Listener {
         this.menuItem = ItemFactory.getMenuItem();
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onJoin(final PlayerJoinEvent event) {
         // Load UltraPlayer whether we use it or not so it's ready
         UltraPlayer up = pm.getUltraPlayer(event.getPlayer());


### PR DESCRIPTION
… other plugins

### What is the purpose of this pull request?

1. _What does it do, and what issues does it solve?_
It changes the EventPriority of the PlayerJoinEvent Listener to normal. This fixes incompatibility with other plugins that clear inventory on join.

#### Changes

- [x ] Use EventPriority Normal so the give menu item doesn't interfere with other plugins (clearing inventory on join for example).
