### PR TITLE
Fixed error when Check-For-Updates is disabled.

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
@@ -227,12 +227,12 @@ public class UltraCosmetics extends JavaPlugin {
             return;
         }
 
+        updateChecker = new UpdateManager(this);
         // Start update checker ASAP so if there's a problem that can be
         // resolved by updating, the user knows there's an update.
         // (We can't start it before the config loader because we need config settings.)
         if (SettingsManager.getConfig().getBoolean("Check-For-Updates")) {
             getSmartLogger().write("Checking for update...");
-            updateChecker = new UpdateManager(this);
             updateChecker.runTaskAsynchronously(this);
         }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

1. _What does it do, and what issues does it solve?_
Fixes a issue that prevents the plugin from enabling when the Check-For-Updates setting is disabled.

#### Changes

- [x] Fixed error when Check-For-Updates is disabled.
