### PR TITLE
Hide pet name if set to empty String

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -243,7 +243,11 @@ public abstract class Pet extends EntityCosmetic<PetType, Mob> implements Updata
         } else {
             newName = getType().getEntityName(getPlayer());
         }
-        rename.setCustomName(MessageManager.toLegacy(newName));
+
+        // Hide name if name is empty
+        String nameString = MessageManager.toLegacy(newName);
+        getEntity().setCustomNameVisible(!nameString.equals(""));
+        rename.setCustomName(nameString);
     }
 
     @Override


### PR DESCRIPTION
### What is the purpose of this pull request?

1. _What does it do, and what issues does it solve?_
This pull request makes pet names hide themselves when an empty String is entered. Previously, the name would be empty, but because of the entity's CustomNameVisibilty set to true, it would still show some translucent pixels.

#### Changes

- [ ] Set pet's Custom Name Visibility depending on the name provided
